### PR TITLE
Add python3 to script

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,8 @@ Preload python models:
 
 ```sh
 % python scripts/preload_models.py
+(or - depending on your python installation) 
+% python3 scripts/preload_models.py
 ```
 
 Heads up that the script does downloads that are somewhat large, more than 1GB.
@@ -445,6 +447,8 @@ Run:
 
 ```sh
 % python scripts/dream.py --full_precision  # half-precision requires autocast and won't work
+(or)
+% python3 scripts/dream.py --full_precision
 ```
 
 You should see output such as:


### PR DESCRIPTION
 You use python3 as a command earlier ('which python3') earlier in the instructions.  For me and for others - because OS X has a default python installation, I need to use python3 throughout including for the scripts to access the correct homebrew version of python. 

Either way - shouldn't it be consistent python3 or python?

By the way - thank you kindly for taking the time to make this super helpful list and description.